### PR TITLE
feat: Alert 대신 대체텍스트 작성

### DIFF
--- a/src/pages/SignIn/SignIn.tsx
+++ b/src/pages/SignIn/SignIn.tsx
@@ -24,7 +24,6 @@ const SignIn = () => {
     try {
       const result = await SignInHandle(email, password);
       if (result.status === 200 && result.data.access_token) {
-        alert('환영합니다.');
         localStorage.setItem('jwt_token', result.data.access_token);
         setError('');
         setEmail('');
@@ -33,7 +32,11 @@ const SignIn = () => {
       }
     } catch (err) {
       if (axios.isAxiosError(err) && err.response) {
-        setError(err.response.data.message);
+        if (err.response.status === 401) {
+          setError('아이디 혹은 비밀번호를 다시 확인해주세요!');
+        } else if (err.response.status === 404) {
+          setError('존재하지 않는 회원입니다!');
+        }
       } else {
         console.error(err);
       }


### PR DESCRIPTION
Signin 페이지에 있던 Alert 대신 로그인 과정에서 발생하는 에러 코드에 따른 대체 텍스트 작성

예)
401 : '아이디 혹은 비밀번호를 다시 확인해주세요!'
404 : '존재하지 않는 회원입니다!'